### PR TITLE
Create the gitignore template using gitignore.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,31 @@
 .idea/
+
+# Credits to gitignore.io for the Java .gitignore template
+# Created by https://www.toptal.com/developers/gitignore/api/java
+# Edit at https://www.toptal.com/developers/gitignore?templates=java
+
+### Java ###
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*


### PR DESCRIPTION
Used the [GitIgnore](https://gitignore.io/) website for the Java `.gitignore` file.

Credits: [https://gitignore.io/](https://gitignore.io/)